### PR TITLE
Patch for making sever.py work with Nuke10.x

### DIFF
--- a/nukeExternalControl/server.py
+++ b/nukeExternalControl/server.py
@@ -193,7 +193,10 @@ class NukeInternal(object):
             elif action == "setitem":
                 obj[params[0]] = params[1]
             elif action == "call":
-                result = nuke.executeInMainThreadWithResult(obj, args=params['args'], kwargs=params['kwargs'])
+                if nuke.NUKE_VERSION_MAJOR < 10:
+                    result = nuke.executeInMainThreadWithResult(obj, args=params['args'], kwargs=params['kwargs'])
+                else:
+                    result = obj(*params['args'], **params['kwargs'])
             elif action == "len":
                 result = len(obj)
             elif action == "str":


### PR DESCRIPTION
As mentioned in your issue tracker I've been having trouble running this package in Nuke10.x. Some digging traced the issue to this part of the server code.
After using this for a while without issues and getting a "blessing" from The Foundry (like they can't see anything wrong with doing it this way) I thought I'd submit this pull request. 

Here is a quote from The Foundry support on why `nuke.executeInMainThreadWithResult()` behaves differently in Nuke10.x:

> I have asked our developers about why this happens in newer versions of Nuke, and they said this was a deliberate change as in some situations Nuke would error silently in the background when calling nuke.executeInMainThread() in the main thread, so this error message was added to prevent this occurrence.
